### PR TITLE
Make the site work on small displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,11 +204,14 @@ scrolls new APP_NAME --scrolls postgresql github eycloud
 <h2>License</h2>
 
 <p>App Scrolls and its scrolls are distributed under the MIT License. See <a href="https://github.com/drnic/appscrolls/blob/master/MIT_LICENSE">MIT_LICENSE</a> for the actual words.</p>
+
+<h2>Acknowledgements</h2>
+
+<p>This project is maintained by <a href="https://drnicwilliams.com">drnic</a>. Thanks to his employer <a href="http://www.engineyard.com">Engine Yard</a>. Thanks to original <a href="http://railswizard.org">Rails Wizard</a> and the wonderful <a href="https://github.com/mbleigh">mbleigh</a>.</p>
+
+<p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
+
       </section>
-      <footer>
-        <p>This project is maintained by <a href="https://drnicwilliams.com">drnic</a>. Thanks to his employer <a href="http://www.engineyard.com">Engine Yard</a>. Thanks to original <a href="http://railswizard.org">Rails Wizard</a> and the wonderful <a href="https://github.com/mbleigh">mbleigh</a>.</p>
-        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
-      </footer>
     </div>
     <script src="javascripts/scale.fix.js"></script>
               <script type="text/javascript">


### PR DESCRIPTION
Moved the content from the fixed-position sidebar footer into an "Acknowledgements" section at the bottom of the main content area. Now everything shows properly on a 13" display, and the browser window can be made even shorter without anything breaking.

Fixes issue #5
