### PR TITLE
Adding RailsAdmin as an alternative admin gem

### DIFF
--- a/scrolls/rails_admin.rb
+++ b/scrolls/rails_admin.rb
@@ -1,0 +1,16 @@
+gem 'rails_admin', :git => 'git://github.com/sferik/rails_admin.git'
+
+after_bundler do
+	generate rails_admin:install
+end
+
+__END__
+
+name: RailsAdmin
+description: "RailsAdmin is a Rails engine that provides an easy-to-use interface for managing your data."
+website: https://github.com/sferik/rails_admin
+author: bcohen
+
+exclusive: administration
+category: administration
+tags: [administration]


### PR DESCRIPTION
For users wishing to use the RailsAdmin interface rather than ActiveAdmin.
