### PR TITLE
perform 1 git commit per recipe (instead of a giant one).

### DIFF
--- a/scrolls/git.rb
+++ b/scrolls/git.rb
@@ -1,4 +1,4 @@
-after_everything do
+before_everything do
   git :init
   git :add => '.'
   git :commit => '-m "Initial import."'

--- a/templates/helpers.erb
+++ b/templates/helpers.erb
@@ -37,9 +37,22 @@ end
 @current_scroll = nil
 @configs = {}
 
+@before_everything_blocks = []
+def before_everything(&block); @before_everything_blocks << [@current_scroll, block]; end
 @after_blocks = []
 def after_bundler(&block); @after_blocks << [@current_scroll, block]; end
 @after_everything_blocks = []
 def after_everything(&block); @after_everything_blocks << [@current_scroll, block]; end
 @before_configs = {}
 def before_config(&block); @before_configs[@current_scroll] = block; end
+
+def git_commit(message)
+  `git add .`
+  `git commit -m "#{message}"`
+end
+
+def execute_block(block)
+  config = @configs[block[0]] || {}
+  @current_scroll = block[0];
+  block[1].call
+end

--- a/templates/layout.erb
+++ b/templates/layout.erb
@@ -19,12 +19,20 @@ end
 RUBY
 
 @scrolls = <%= resolve_scrolls.map(&:key).inspect %> 
+use_git = @scrolls.include?('git')
 
 <%= render "helpers" %>
 
 <% resolve_scrolls.each do |scroll| %>
 <%= render 'scroll', scroll.get_binding %>
 <% end %>
+
+
+say_wizard "Running before_everything callbacks."
+@before_everything_blocks.each do |b|
+  execute_block(b)
+  git_commit("recipe : '#{b.first}'") if use_git
+end
 
 <% if custom_code? %># >-----------------------------[ Custom Code ]-------------------------------<
 
@@ -36,9 +44,19 @@ RUBY
 
 say_wizard "Running Bundler install. This will take a while."
 run 'bundle install'
+git_commit("recipe : 'bundle install'") if use_git
+
+
 say_wizard "Running after Bundler callbacks."
-@after_blocks.each{|b| config = @configs[b[0]] || {}; @current_scroll = b[0]; b[1].call}
+@after_blocks.each do |b|
+  execute_block(b)
+  git_commit("recipe : '#{b.first}'") if use_git
+end
 
 @current_scroll = nil
-say_wizard "Running after everything callbacks."
-@after_everything_blocks.each{|b| config = @configs[b[0]] || {}; @current_scroll = b[0]; b[1].call}
+say_wizard "Running after_everything callbacks."
+@after_everything_blocks.each do |b|
+  execute_block(b)
+  git_commit("recipe : '#{b.first}'") if use_git
+end
+

--- a/templates/layout.erb
+++ b/templates/layout.erb
@@ -44,7 +44,7 @@ end
 
 say_wizard "Running Bundler install. This will take a while."
 run 'bundle install'
-git_commit("recipe : 'bundle install'") if use_git
+git_commit("bundle install") if use_git
 
 
 say_wizard "Running after Bundler callbacks."


### PR DESCRIPTION
smaller commits document better the action of each recipe.
