### PR TITLE
Added option to create and use local scrolls in ENV['APPSCROLLS_DIR']

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,8 +54,11 @@ task :new do
   require 'active_support/inflector'
   require 'erb'
   require 'appscrolls/template'
+  unless (scrolls_dir = ENV["APPSCROLLS_DIR"]) and scrolls_dir != ""
+    scrolls_dir = "scrolls"
+  end
   scroll = AppScrollsScrolls::Template.render("new_scroll", binding)
-  scroll_path = "scrolls/#{name}.rb"
+  scroll_path = "#{scrolls_dir}/#{name}.rb"
   File.open(scroll_path, "w") { |file| file << scroll }
   `open #{scroll_path}`
 end

--- a/lib/appscrolls.rb
+++ b/lib/appscrolls.rb
@@ -3,8 +3,20 @@ require 'appscrolls/scroll'
 require 'appscrolls/config'
 require 'appscrolls/template'
 
-Dir[File.dirname(__FILE__) + '/../scrolls/*.rb'].each do |path|
+def enroll_scroll_at(path)
   key = File.basename(path, '.rb')
   scroll = AppScrollsScrolls::Scroll.generate(key, File.open(path))
   AppScrollsScrolls::Scrolls.add(scroll)
+end
+
+# set up local scrolls if available
+if dir = ENV['APPSCROLLS_DIR'] and dir != ""
+  Dir[dir + '/*.rb'].each do |path|
+    enroll_scroll_at(path)
+  end
+end
+
+# default files of same keys as local scrolls are discarded
+Dir[File.dirname(__FILE__) + '/../scrolls/*.rb'].each do |path|
+  enroll_scroll_at(path)
 end

--- a/lib/appscrolls/scrolls.rb
+++ b/lib/appscrolls/scrolls.rb
@@ -4,6 +4,8 @@ module AppScrollsScrolls
     @@list = {}
 
     def self.add(scroll)
+      sym = ActiveSupport::Inflector.camelize(scroll.key.gsub("-", "_"))
+      return if AppScrollsScrolls::Scrolls.const_defined?(sym)
       AppScrollsScrolls::Scrolls.const_set ActiveSupport::Inflector.camelize(scroll.key.gsub("-", "_")), scroll
       @@list[scroll.key] = scroll
       (@@categories[scroll.category.to_s] ||= []) << scroll.key

--- a/spec/appscrolls/scrolls_spec.rb
+++ b/spec/appscrolls/scrolls_spec.rb
@@ -16,6 +16,13 @@ describe AppScrollsScrolls::Scrolls do
     subject.list.should be_include('scroll_test')
   end
 
+  it '.add should not overwrite scroll of same key' do
+    new_scroll = AppScrollsScrolls::Scroll.generate("scroll_test", "# Overwrite Testing", :name => "New Test Scroll", :category => "test", :description => "Just an overwrite test.")
+    AppScrollsScrolls::Scrolls.add(new_scroll)
+    subject["scroll_test"].should eql(scroll)
+    subject["scroll_test"].should_not eql(new_scroll)
+  end
+
   describe '.for' do
     it 'should find for a given category' do
       AppScrollsScrolls::Scrolls.for('test').should be_include('scroll_test')


### PR DESCRIPTION
'rake new' creates new scrolls in ENV['APPSCROLLS_DIR'] if specified
appscrolls.rb reads local scrolls in  ENV['APPSCROLLS_DIR']
default scroll of the same names as local scrolls are discarded
