### PR TITLE
add --save NAME option to save your chosen scrolls when creating an app

### DIFF
--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -36,6 +36,11 @@ module AppScrollsScrolls
       lines.each_with_index do |line, i|
         puts "#{i}: #{line}"
       end
+      if options[:save]
+        print "Enter line number and name to save to a new scroll (e.g. 1 my_defaults): "
+        index, name = STDIN.gets.strip.split(' ')
+        create_new_scroll(:scrolls => lines[index.to_i].chomp.split(' '), :name => name)
+      end
     end
 
     desc "list [CATEGORY]", "list available scrolls (optionally by category)"
@@ -116,6 +121,17 @@ module AppScrollsScrolls
         File.open(history_file, "a") do |file|
           file.puts scrolls.join(' ')
         end
+      end
+
+      def create_new_scroll(hash)
+        require 'active_support/inflector'
+        require 'erb'
+        require 'appscrolls/template'
+        name = hash[:name]
+        requires = hash[:scrolls]
+        scroll = AppScrollsScrolls::Template.render("saved_scrolls", binding)
+        scroll_path = "scrolls/#{name}.rb"
+        File.open(scroll_path, "w") { |file| file << scroll }
       end
     end
   end

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -7,15 +7,11 @@ module AppScrollsScrolls
     desc "new APP_NAME", "create a new Rails app"
     method_option :scrolls, :type => :array, :aliases => "-s", :desc => "List scrolls, e.g. -s resque rails_basics jquery"
     method_option :save, :desc => "Save the selection of scrolls. Usage: '--save NAME'"
-    method_option :use, :desc => "Use a saved set of scrolls. Usage: '--use NAME'"
     method_option :template, :type => :boolean, :aliases => "-t", :desc => "Only display template that would be used"
     def new(name)
       if options[:scrolls]
         run_template(name, options[:scrolls], options[:template])
         save_scroll_selections if options[:save]
-      elsif options[:use]
-        scrolls = get_existing_saves
-        run_template(name, scrolls[options[:use]], options[:template])
       else
         @scrolls = []
 

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -31,6 +31,7 @@ module AppScrollsScrolls
 
     desc "history", "view history of past scroll choices"
     method_option :save, :desc => "Save a past choice of scrolls to a new scroll."
+    method_option :use, :desc => "Directly use a past choice of scrolls to generate a new app."
     def history
       lines = File.readlines history_file
       lines.each_with_index do |line, i|
@@ -40,6 +41,10 @@ module AppScrollsScrolls
         print "Enter line number and name to save to a new scroll (e.g. 1 my_defaults): "
         index, name = STDIN.gets.strip.split(' ')
         create_new_scroll(:scrolls => lines[index.to_i].chomp.split(' '), :name => name)
+      elsif options[:use]
+        print "Enter line number and name to create a new scroll from past selection (e.g. 1 new_app_name): "
+        index, name = STDIN.gets.strip.split(' ')
+        run_template(name, lines[index.to_i].chomp.split(' '))
       end
     end
 

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -6,10 +6,12 @@ module AppScrollsScrolls
     include Thor::Actions
     desc "new APP_NAME", "create a new Rails app"
     method_option :scrolls, :type => :array, :aliases => "-s", :desc => "List scrolls, e.g. -s resque rails_basics jquery"
+    method_option :save, :desc => "Save the selection of scrolls. Usage: '--save NAME'"
     method_option :template, :type => :boolean, :aliases => "-t", :desc => "Only display template that would be used"
     def new(name)
       if options[:scrolls]
         run_template(name, options[:scrolls], options[:template])
+        save_scroll_selections if options[:save]
       else
         @scrolls = []
 
@@ -87,6 +89,16 @@ module AppScrollsScrolls
         end
       ensure
         file.unlink
+      end
+
+      def save_scroll_selections
+        save_file = File.join(ENV['HOME'], '.saved_scrolls')
+        saved_scrolls = File.exists?(save_file) ? YAML.load_file(save_file) : {}
+        saved_scrolls[options[:save]] = options[:scrolls]
+
+        File.open(save_file, 'w') do |out|
+           YAML.dump(saved_scrolls, out)
+        end
       end
     end
   end

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -7,11 +7,15 @@ module AppScrollsScrolls
     desc "new APP_NAME", "create a new Rails app"
     method_option :scrolls, :type => :array, :aliases => "-s", :desc => "List scrolls, e.g. -s resque rails_basics jquery"
     method_option :save, :desc => "Save the selection of scrolls. Usage: '--save NAME'"
+    method_option :use, :desc => "Use a saved set of scrolls. Usage: '--use NAME'"
     method_option :template, :type => :boolean, :aliases => "-t", :desc => "Only display template that would be used"
     def new(name)
       if options[:scrolls]
         run_template(name, options[:scrolls], options[:template])
         save_scroll_selections if options[:save]
+      elsif options[:use]
+        scrolls = get_existing_saves
+        run_template(name, scrolls[options[:use]], options[:template])
       else
         @scrolls = []
 
@@ -91,14 +95,19 @@ module AppScrollsScrolls
         file.unlink
       end
 
+      def saved_scroll_filename
+        File.join(ENV['HOME'], '.saved_scrolls')
+      end
+
+      def get_existing_saves
+        File.exists?(saved_scroll_filename) ? YAML.load_file(saved_scroll_filename) : {}
+      end
+
       def save_scroll_selections
-        save_file = File.join(ENV['HOME'], '.saved_scrolls')
-        saved_scrolls = File.exists?(save_file) ? YAML.load_file(save_file) : {}
+        saved_scrolls = get_existing_saves
         saved_scrolls[options[:save]] = options[:scrolls]
 
-        File.open(save_file, 'w') do |out|
-           YAML.dump(saved_scrolls, out)
-        end
+        File.open(saved_scroll_filename, 'w') { |out| YAML.dump(saved_scrolls, out) }
       end
     end
   end

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -11,13 +11,14 @@ module AppScrollsScrolls
     def new(name)
       if options[:scrolls]
         run_template(name, options[:scrolls], options[:template])
-        save_scroll_selections if options[:save]
+        save_scroll_selections(options[:scrolls]) if options[:save]
       else
         @scrolls = []
 
         while scroll = ask("#{print_scrolls}#{bold}Which scroll would you like to add? #{clear}#{yellow}(blank to finish)#{clear}")
           if scroll == ''
             run_template(name, @scrolls)
+            save_scroll_selections(@scrolls) if options[:save]
             break
           elsif AppScrollsScrolls::Scrolls.list.include?(scroll)
             @scrolls << scroll
@@ -91,19 +92,14 @@ module AppScrollsScrolls
         file.unlink
       end
 
-      def saved_scroll_filename
-        File.join(ENV['HOME'], '.saved_scrolls')
-      end
-
-      def get_existing_saves
-        File.exists?(saved_scroll_filename) ? YAML.load_file(saved_scroll_filename) : {}
-      end
-
-      def save_scroll_selections
-        saved_scrolls = get_existing_saves
-        saved_scrolls[options[:save]] = options[:scrolls]
-
-        File.open(saved_scroll_filename, 'w') { |out| YAML.dump(saved_scrolls, out) }
+      def save_scroll_selections(requires)
+        require 'active_support/inflector'
+        require 'erb'
+        require 'appscrolls/template'
+        name = options[:save]
+        scroll = AppScrollsScrolls::Template.render("saved_scrolls", binding)
+        scroll_path = "scrolls/#{name}.rb"
+        File.open(scroll_path, "w") { |file| file << scroll }
       end
     end
   end

--- a/templates/saved_scrolls.erb
+++ b/templates/saved_scrolls.erb
@@ -1,0 +1,19 @@
+
+__END__
+
+name: <%= name.humanize.capitalize %>
+description: 
+website:
+author: <%= `whoami`.strip %>
+
+requires: [<%= requires.join(', ') %>]
+run_after: []
+run_before: []
+
+category: other # authentication, testing, persistence, javascript, css, services, deployment, and templating
+# exclusive: 
+
+# config:
+#   - foo:
+#       type: boolean
+#       prompt: "Is foo true?"


### PR DESCRIPTION
Simple way to save your selections. Considering how to implement pulling them back out and using them when generating. 

On one hand, I thought about overloading the scrolls option to let you do -s saved_name, rather than creating yet another option. At the same time another option would be cleaner and likely more obvious...so maybe I'll spike on that and see how it goes. 

Also, yeah, didn't include tests. Happy to give them a go if you have some guidance on it--I always find testing code like this to sometimes get a bit awkward and unhelpful.
