### PR TITLE
When running interactively, entering a scroll name twice removes it from the template

### DIFF
--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -17,6 +17,10 @@ module AppScrollsScrolls
           if scroll == ''
             run_template(name, @scrolls)
             break
+          elsif @scrolls.include?(scroll)
+            @scrolls.delete(scroll)
+            puts
+            puts "> #{yellow}Removed '#{scroll}' from tempate.#{clear}"
           elsif AppScrollsScrolls::Scrolls.list.include?(scroll)
             @scrolls << scroll
             puts
@@ -67,7 +71,7 @@ module AppScrollsScrolls
         puts
         puts "#{bold}Generating and Running Template...#{clear}"
         puts
-        file = Tempfile.new('template')        
+        file = Tempfile.new('template')
         template = AppScrollsScrolls::Template.new(scrolls)
 
         puts "Using the following scrolls:"

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -58,10 +58,14 @@ module AppScrollsScrolls
         message = "\n\n\n"
         if @scrolls && @scrolls.any?
           message << "#{green}#{bold}Your Scrolls:#{clear} #{@scrolls.join(", ")}"
-          message << "\n"
+          message << "\n\n"
         end
-        message << "#{bold}#{cyan}Available Scrolls:#{clear} #{AppScrollsScrolls::Scrolls.list.join(', ')}"
-        message << "\n\n"
+        available_scrolls = AppScrollsScrolls::Scrolls.list - @scrolls
+        if available_scrolls.any?
+          message << "#{bold}#{cyan}Available Scrolls:#{clear} #{available_scrolls.join(', ')}"
+          message << "\n\n"
+        end
+        message
       end
 
       def run_template(name, scrolls, display_only = false)

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -13,11 +13,9 @@ module AppScrollsScrolls
       else
         @scrolls = []
 
-        while scroll = ask("#{print_scrolls}#{bold}Which scroll would you like to add? #{clear}#{yellow}(blank to finish)#{clear}")
-          if scroll == ''
-            run_template(name, @scrolls)
-            break
-          elsif @scrolls.include?(scroll)
+        question = "#{print_scrolls}#{bold}Which scroll would you like to add? #{clear}#{yellow}(blank to finish)#{clear}"
+        while (scroll = ask(question)) != ''
+          if @scrolls.include?(scroll)
             @scrolls.delete(scroll)
             puts
             puts "> #{yellow}Removed '#{scroll}' from tempate.#{clear}"
@@ -30,6 +28,8 @@ module AppScrollsScrolls
             puts "> #{red}Invalid scroll, please try again.#{clear}"
           end
         end
+
+        run_template(name, @scrolls)
       end
     end
 

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -13,8 +13,8 @@ module AppScrollsScrolls
       else
         @scrolls = []
 
-        question = "#{print_scrolls}#{bold}Which scroll would you like to add/remove? #{clear}#{yellow}(blank to finish)#{clear}"
-        while (scroll = ask(question)) != ''
+        question = "#{bold}Which scroll would you like to add/remove? #{clear}#{yellow}(blank to finish)#{clear}"
+        while (scroll = ask(scrolls_message + question)) != ''
           if @scrolls.include?(scroll)
             @scrolls.delete(scroll)
             puts
@@ -54,16 +54,14 @@ module AppScrollsScrolls
       def green; "\033[32m" end
       def yellow; "\033[33m" end
 
-      def print_scrolls
-        puts
-        puts
-        puts
+      def scrolls_message
+        message = "\n\n\n"
         if @scrolls && @scrolls.any?
-          puts "#{green}#{bold}Your Scrolls:#{clear} " + @scrolls.join(", ")
-          puts
+          message << "#{green}#{bold}Your Scrolls:#{clear} #{@scrolls.join(", ")}"
+          message << "\n"
         end
-        puts "#{bold}#{cyan}Available Scrolls:#{clear} " + AppScrollsScrolls::Scrolls.list.join(', ')
-        puts
+        message << "#{bold}#{cyan}Available Scrolls:#{clear} #{AppScrollsScrolls::Scrolls.list.join(', ')}"
+        message << "\n\n"
       end
 
       def run_template(name, scrolls, display_only = false)

--- a/lib/appscrolls/command.rb
+++ b/lib/appscrolls/command.rb
@@ -13,12 +13,12 @@ module AppScrollsScrolls
       else
         @scrolls = []
 
-        question = "#{print_scrolls}#{bold}Which scroll would you like to add? #{clear}#{yellow}(blank to finish)#{clear}"
+        question = "#{print_scrolls}#{bold}Which scroll would you like to add/remove? #{clear}#{yellow}(blank to finish)#{clear}"
         while (scroll = ask(question)) != ''
           if @scrolls.include?(scroll)
             @scrolls.delete(scroll)
             puts
-            puts "> #{yellow}Removed '#{scroll}' from tempate.#{clear}"
+            puts "> #{yellow}Removed '#{scroll}' from template.#{clear}"
           elsif AppScrollsScrolls::Scrolls.list.include?(scroll)
             @scrolls << scroll
             puts


### PR DESCRIPTION
Currently, if a scroll name is entered and then entered again, it is added twice to the
list of scrolls to be templated. This instead changes the behaviour so that if a scroll
has already been entered, then it is instead removed when its name is entered again.
