### PR TITLE
Set external encoding to UTF-8 to support unicode characters

### DIFF
--- a/bin/appscrolls
+++ b/bin/appscrolls
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 $:.push File.dirname(__FILE__) + '/../lib'
 
+Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > '1.8.7'
+
 require 'rubygems'
 require 'appscrolls/command'
 

--- a/bin/scrolls
+++ b/bin/scrolls
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 $:.push File.dirname(__FILE__) + '/../lib'
 
+Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > '1.8.7'
+
 require 'rubygems'
 require 'appscrolls/command'
 


### PR DESCRIPTION
Running `scrolls list` on my machine (pretty clean install of OS X Lion) dies with

```
/Users/darthdeus/.rbenv/versions/1.9.2-p320/lib/ruby/gems/1.9.1/gems/appscrolls 0.8.4/lib/appscrolls/scroll.rb:30:in 
`split': invalid byte sequence in US-ASCII (ArgumentError)`
```

This can be easily fixed by forcing external encoding to UTF8. It happens only on systems which don't have a proper locale set up (at least that's what I've observed.

```
$ locale                                                                                                       
LANG=
LC_COLLATE="C"
LC_CTYPE="C"
LC_MESSAGES="C"
LC_MONETARY="C"
LC_NUMERIC="C"
LC_TIME="C"
LC_ALL=
```

The bug is also specific to Ruby 1.9, that's why there is a conditional on RUBY_VERSION.
